### PR TITLE
Freshness pass: add new projects + mark repos inactive >1 year

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ There is also an overwhelming amount of papers describing techniques related to 
 * [Harvey](https://diligence.security/blog/2019/01/fuzzing-smart-contracts-using-multiple-transactions/): A fuzzer for Ethereum smart contracts.
 * [hevm](https://github.com/argotorg/hevm): hevm is many things as you will see below, including a fuzzer. The fuzzer can also be used to try to break invariants.
     - Article: [Symbolic Execution With ds-test](https://fv.ethereum.org/2020/12/11/symbolic-execution-with-ds-test/), David Terry.
+* [ItyFuzz](https://github.com/fuzzland/ityfuzz): Snapshot-based hybrid fuzzer for EVM (and MoveVM) bytecode that combines fuzzing with symbolic execution to reach deep states quickly.
+    - Paper: [ItyFuzz: Snapshot-Based Fuzzer for Smart Contract](https://arxiv.org/abs/2306.17135), Chaofan Shou, Shangyin Tan, Koushik Sen (ISSTA 2023).
 
 ### Economics / Game Theory
 
@@ -70,15 +72,19 @@ There is also an overwhelming amount of papers describing techniques related to 
 * [EVM-Dafny](https://github.com/Consensys/evm-dafny): A formal and executable semantics of the EVM in Dafny.
     - Paper (FM23): [Formal and Executable Semantics of the Ethereum Virtual Machine in Dafny](https://link.springer.com/chapter/10.1007/978-3-031-27481-7_32), Franck Cassez et al. (2023).
     - Paper (arXiv version): [Formal and Executable Semantics of the Ethereum Virtual Machine in Dafny](https://arxiv.org/abs/2303.00152), Franck Cassez et al. (2023).
+* [evm-smith](https://github.com/leonardoalt/evm-smith): A framework for AI systems to write EVM bytecode and prove it safe, built on EVMYulLean.
+* [EVMYulLean](https://github.com/NethermindEth/EVMYulLean): An executable formal model of the EVM and the Yul IR in Lean 4.
 * [GASOL](https://github.com/costa-group/gasol-optimizer): A generic framework that optimizes smart contracts by applying the technique called "super-optimization" that consists in optimizing basic blocks.
 	- Paper: [A Max-SMT Superoptimizer for EVM handling Memory and Storage](https://doi.org/10.1007/978-3-030-99524-9_4). Elvira Albert, Pablo Gordillo, Alejandro Hernández-Cerezo and Albert Rubio, TACAS 2022.
 	- Paper: [Super-Optimization of Smart Contracts](https://doi.org/10.1145/3506800). Elvira Albert, Pablo Gordillo, Alejandro Hernández-Cerezo, Albert Rubio and Maria A. Schett, 2022.
+* [Halmos](https://github.com/a16z/halmos): Symbolic testing tool (a16z) that symbolically executes Foundry/Solidity tests to prove or refute assertions over all possible inputs.
 * [hevm](https://github.com/argotorg/hevm): Symbolic execution engine and equivalence checker for EVM code.
     - Article: [Symbolic Execution With ds-test](https://fv.ethereum.org/2020/12/11/symbolic-execution-with-ds-test/), David Terry.
     - Article: [Symbolic execution for hevm](https://fv.ethereum.org/2020/07/28/symbolic-hevm-release/), Martin Lundfall.
 * [KEVM](https://github.com/runtimeverification/evm-semantics): K Semantics of the Ethereum Virtual Machine (EVM).
     - Talk: [KEVM Overview](https://www.youtube.com/watch?v=tIq_xECoicQ).
     - Paper: [KEVM: A Complete Semantics of the Ethereum Virtual Machine](https://www.ideals.illinois.edu/items/102260), Everett Hildenbrandt et al. (2017).
+* [Kontrol](https://github.com/runtimeverification/kontrol): Combines KEVM and Foundry to let developers run K-framework symbolic-execution proofs directly from their Solidity test suites.
 * [Manticore](https://github.com/trailofbits/manticore): EVM bytecode analysis tool based on symbolic execution.
     - Article: [Manticore: Symbolic execution for humans](https://blog.trailofbits.com/2017/04/27/manticore-symbolic-execution-for-humans/).
     - Workshop: [Using Manticore and Symbolic Execution to Find Smart Contracts Bugs - Devcon IV](https://github.com/trailofbits/publications/tree/master/workshops/Using%20Manticore%20and%20Symbolic%20Execution%20to%20Find%20Smart%20Contracts%20Bugs%20-%20Devcon%204).
@@ -99,6 +105,8 @@ There is also an overwhelming amount of papers describing techniques related to 
 
 ### Solidity
 
+* [Clear](https://github.com/NethermindEth/Clear): Interactive formal-verification framework for Yul/Solidity programs, built on Nethermind's Lean model of the Yul EVM dialect.
+* [Pyrometer](https://github.com/nascentxyz/pyrometer): Combines abstract interpretation, symbolic execution, and static analysis to perform value-range and reachability (bound) analysis on Solidity.
 * [Slither](https://github.com/crytic/slither): Solidity static analysis framework that checks for specific vulnerabilities.
     - Article: [Slither – a Solidity static analysis framework](https://blog.trailofbits.com/2018/10/19/slither-a-solidity-static-analysis-framework/).
 * [SmartAce](https://github.com/contract-ace/smartace): An automated framework for smart contract verification.
@@ -129,6 +137,8 @@ There is also an overwhelming amount of papers describing techniques related to 
     - Slides: [Formal Verification of Smart Contracts and Protocols: What, Why, How - Devcon V](https://github.com/microsoft/verisol/blob/master/Docs/devcon5-verisol.pptx), Shuvendu Lahiri et al.
     - Article: [Researchers work to secure Azure Blockchain smart contracts with formal verification](https://www.microsoft.com/en-us/research/blog/researchers-work-to-secure-azure-blockchain-smart-contracts-with-formal-verification/), Microsoft Research Blog.
     - Paper: [Formal Specification and Verification of Smart Contracts for Azure Blockchain](https://arxiv.org/abs/1812.08829), Yuepeng Wang, Shuvendu K. Lahiri, Shuo Chen, Rong Pan, Isil Dillig, Cody Born, Immad Naseer.
+* [Verity](https://github.com/lfglabs-dev/verity): A Lean-based EDSL to specify, implement, and prove Ethereum smart contracts, compiling verified contracts down to EVM bytecode with machine-checked spec/implementation equivalence. ([veritylang.com](https://veritylang.com))
+* [Wake](https://github.com/Ackee-Blockchain/wake): Python framework combining a Solidity static-analysis detector framework, property-based fuzzing, and developer tooling.
 
 ### Vyper
 
@@ -169,9 +179,20 @@ There is also an overwhelming amount of papers describing techniques related to 
 	- [ACL2 Semaphore Docs](https://acl2.org/doc/?topic=ZKSEMAPHORE____SEMAPHORE)
 * [Cairo verification using Lean](https://github.com/starkware-libs/formal-proofs)
 	- Paper: [A verified algebraic representation of Cairo program execution](https://github.com/starkware-libs/formal-proofs), Jeremy Avigad et al.
+* [circomspect](https://github.com/trailofbits/circomspect): Trail of Bits static analyzer/linter for Circom circuits, with multiple passes that flag under-constrained signals and other circuit bugs.
+* [circuzz](https://github.com/Rigorous-Software-Engineering/circuzz): Metamorphic and differential fuzzing pipeline for zero-knowledge circuit compiler toolchains.
+* [CIVER](https://github.com/costa-group/circom_civer): Modular verifier of weak safety (absence of under-constrained signals), tag specifications, and pre/postconditions for Circom circuits.
+* [Coda](https://eprint.iacr.org/2023/547): A statically-typed language for ZK circuits with a refinement type system that discharges proof obligations to Coq.
 * [Ecne](https://github.com/franklynwang/EcneProject): An engine for verifying the soundness of R1CS constraints.
+* [gnark-lean-extractor](https://github.com/reilabs/gnark-lean-extractor): Extracts gnark (zk-SNARK library) circuits defined in Go into Lean for formal verification.
+* [Korrekt (halo2-analyzer)](https://github.com/quantstamp/halo2-analyzer): Uses abstract interpretation and SMT to detect under-constrained cells and unused gates/columns in Halo2 (PLONKish) circuits.
 * [Leo](https://github.com/ProvableHQ/leo)
 	- Paper: [LEO: A Programming Language for Formally Verified, Zero-Knowledge Applications](https://eprint.iacr.org/2021/651.pdf)
+* [Picus](https://github.com/Veridise/Picus): Automated verifier (Veridise) for the uniqueness / under-constrained property of ZKP circuits (Circom, R1CS, gnark), using SMT solvers.
+* [Verified zk(E)VM](https://github.com/Verified-zkEVM): A research effort accelerating the application of formal verification to zk(E)VMs in Lean ([verified-zkevm.org](https://verified-zkevm.org)).
+	- [ArkLib](https://github.com/Verified-zkEVM/ArkLib): Formally verified arguments of knowledge in Lean.
+	- [clean](https://github.com/Verified-zkEVM/clean): A verified Lean circuit DSL.
+* [zkFuzz](https://github.com/Koukyosyumei/zkFuzz): Program-mutation fuzzing framework for ZK circuits, formalizing a Trace-Constraint Consistency Test to find under/over-constraint bugs.
 
 ## Other Lists
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The lists are not complete, and you are encouraged to visit the project pages to
 
 Please do not hesitate to open an issue/PR if you have information that is not present here or if you find a mistake.
 
-> **Maintenance status:** entries marked ⚠️ are archived or no longer actively maintained. They are kept for historical reference and listed at the end of their section.
+> **Maintenance status:** entries marked ⚠️ are archived or have had no commits in over a year (as of June 2026). They are kept for historical reference; an inactive project may still be perfectly usable.
 
 ## Contents
 
@@ -33,7 +33,7 @@ There is also an overwhelming amount of papers describing techniques related to 
 
 ### Learning
 
-* [Formal Methods for DeFi Developers](https://github.com/WilfredTA/formal-methods-curriculum/): a course sequence for training developers in the use & development of formal methods and formal tools.
+* [Formal Methods for DeFi Developers](https://github.com/WilfredTA/formal-methods-curriculum/): a course sequence for training developers in the use & development of formal methods and formal tools. ⚠️ _No commits since 2022-07._
 
 ### Specification
 
@@ -54,7 +54,7 @@ There is also an overwhelming amount of papers describing techniques related to 
 
 ### Economics / Game Theory
 
-* [Clockwork Finance Framework](https://github.com/defi-formal/cff/): A general purpose formal verification framework and mechanized proof system for reasoning about economic security properties of composed DeFi contracts, using K framework's symbolic execution engine and model checker.
+* [Clockwork Finance Framework](https://github.com/defi-formal/cff/): A general purpose formal verification framework and mechanized proof system for reasoning about economic security properties of composed DeFi contracts, using K framework's symbolic execution engine and model checker. ⚠️ _No commits since 2021-09._
    - Paper: [Clockwork Finance: Automated Analysis of Economic Security in Smart Contracts](https://arxiv.org/pdf/2109.04347.pdf)
    - Talk: [Clockwork Finance: Automated Analysis of Economic Security in Smart Contracts - SBC22](https://www.youtube.com/watch?v=n52xBSk2TSs)
    - Slides: [Clockwork Finance](https://www.cs.cornell.edu/~babel/slides/cff_sbc_pdf.pdf)
@@ -63,10 +63,10 @@ There is also an overwhelming amount of papers describing techniques related to 
 
 * [Certora](https://www.certora.com/)
    - Paper: [Finding Bugs Automatically in Smart Contracts with Parameterized Invariants](https://groups.csail.mit.edu/sdg/pubs/2020/sbc2020.pdf), Thomas Bernardi et al (2020)
-* [EthBMC](https://github.com/RUB-SysSec/EthBMC): A Bounded Model Checker for Smart Contracts.
+* [EthBMC](https://github.com/RUB-SysSec/EthBMC): A Bounded Model Checker for Smart Contracts. ⚠️ _No commits since 2022-12._
 * [EtherTrust](https://www.netidee.at/ethertrust): Analysis tool for EVM bytecode.
     - Paper: [Foundations and Tools for the Static Analysis of Ethereum smart contracts](https://link.springer.com/chapter/10.1007/978-3-319-96145-3_4), Ilya Grishchenko et al. (2018).
-* [EthIsabelle](https://github.com/pirapira/eth-isabelle): A Lem formalization of EVM and some Isabelle/HOL proofs.
+* [EthIsabelle](https://github.com/pirapira/eth-isabelle): A Lem formalization of EVM and some Isabelle/HOL proofs. ⚠️ _No commits since 2022-03._
     - Talk: [Formal Verification of Smart Contracts](https://yoichihirai.com/deedtalk.pdf), Yoichi Hirai.
 * [eThor](https://secpriv.wien/ethor/): Static analysis for Ethereum smart contracts.
 * [EVM-Dafny](https://github.com/Consensys/evm-dafny): A formal and executable semantics of the EVM in Dafny.
@@ -88,32 +88,32 @@ There is also an overwhelming amount of papers describing techniques related to 
 * [Manticore](https://github.com/trailofbits/manticore): EVM bytecode analysis tool based on symbolic execution.
     - Article: [Manticore: Symbolic execution for humans](https://blog.trailofbits.com/2017/04/27/manticore-symbolic-execution-for-humans/).
     - Workshop: [Using Manticore and Symbolic Execution to Find Smart Contracts Bugs - Devcon IV](https://github.com/trailofbits/publications/tree/master/workshops/Using%20Manticore%20and%20Symbolic%20Execution%20to%20Find%20Smart%20Contracts%20Bugs%20-%20Devcon%204).
-* [MAIAN](https://github.com/ivicanikolicsg/MAIAN): EVM bytecode analysis tool that checks whether a contract might be suicidal, prodigal or greedy.
+* [MAIAN](https://github.com/ivicanikolicsg/MAIAN): EVM bytecode analysis tool that checks whether a contract might be suicidal, prodigal or greedy. ⚠️ _No commits since 2023-10._
     - Paper: [Finding The Greedy, Prodigal, and Suicidal Contracts at Scale](https://arxiv.org/pdf/1802.06038.pdf), Ivica Nikolic et al. (2018).
 * [Mythril](https://github.com/Consensys/mythril): EVM bytecode security analysis tool that uses concolic analysis, taint analysis and control flow checking.
     - Article: [Practical Smart Contract Security Analysis and Exploitation— Part 1](https://hackernoon.com/practical-smart-contract-security-analysis-and-exploitation-part-1-6c2f2320b0c), Bernhard Mueller.
-* [Securify](https://github.com/eth-sri/securify2): Security scanner for Ethereum smart contracts.
+* [Securify](https://github.com/eth-sri/securify2): Security scanner for Ethereum smart contracts. ⚠️ _No commits since 2025-05._
     - Paper: [Securify: Practical Security Analysis of Smart Contracts](https://files.sri.inf.ethz.ch/website/papers/ccs18-securify.pdf), Petar Tsankov et al. (2018).
 * [Verifereum](https://verifereum.org): Specification of the EVM and full functional verification of EVM bytecode in HOL4.
 * [VerX](http://verx.ch/): Full functional verification for Ethereum smart contracts.
     - Paper: [VerX: Safety Verification of Smart Contracts](https://files.sri.inf.ethz.ch/website/papers/sp20-verx.pdf), Permenev et al. (2019).
-* [KLab](https://github.com/dapphub/klab): K framework proof explorer and smart contract specification format. ⚠️ _Archived / no longer maintained._
+* [KLab](https://github.com/dapphub/klab): K framework proof explorer and smart contract specification format. ⚠️ _Archived; no commits since 2021-08._
     - Tutorial: [KLab](https://youtu.be/z4mIo38x1u8), Everett Hildenbrandt.
     - Workshop: Formal Verification Workshop Using KLab - Devcon IV. Could not find video/slides.
-* [Oyente](https://github.com/enzymefinance/oyente): EVM bytecode analysis tool based on symbolic execution. ⚠️ _Archived / no longer maintained._
+* [Oyente](https://github.com/enzymefinance/oyente): EVM bytecode analysis tool based on symbolic execution. ⚠️ _Archived; no commits since 2023-01._
     - Paper: [Making Smart Contracts Smarter](https://eprint.iacr.org/2016/633.pdf), Loi Luu et al. (2016).
 
 ### Solidity
 
 * [Clear](https://github.com/NethermindEth/Clear): Interactive formal-verification framework for Yul/Solidity programs, built on Nethermind's Lean model of the Yul EVM dialect.
-* [Pyrometer](https://github.com/nascentxyz/pyrometer): Combines abstract interpretation, symbolic execution, and static analysis to perform value-range and reachability (bound) analysis on Solidity.
+* [Pyrometer](https://github.com/nascentxyz/pyrometer): Combines abstract interpretation, symbolic execution, and static analysis to perform value-range and reachability (bound) analysis on Solidity. ⚠️ _No commits since 2025-02._
 * [Slither](https://github.com/crytic/slither): Solidity static analysis framework that checks for specific vulnerabilities.
     - Article: [Slither – a Solidity static analysis framework](https://blog.trailofbits.com/2018/10/19/slither-a-solidity-static-analysis-framework/).
-* [SmartAce](https://github.com/contract-ace/smartace): An automated framework for smart contract verification.
+* [SmartAce](https://github.com/contract-ace/smartace): An automated framework for smart contract verification. ⚠️ _No commits since 2022-01._
 	- Paper: [Verifying Solidity Smart Contracts Via Communication Abstraction in SmartACE](https://mariachris.github.io/Pubs/VMCAI-2022.pdf), Scott Wesley et al. (2022).
-* [SmartCheck](https://github.com/smartdec/smartcheck): Static analysis tool for discovering vulnerabilities in Solidity contracts.
+* [SmartCheck](https://github.com/smartdec/smartcheck): Static analysis tool for discovering vulnerabilities in Solidity contracts. ⚠️ _No commits since 2023-05._
     - Paper: [SmartCheck: static analysis of ethereum smart contracts](https://dl.acm.org/doi/10.1145/3194113.3194115), Sergei Tikhomirov et al. (2018).
-* [Solidifier](https://github.com/blockhousetech/research/tree/master/Solidifier): Bounded Model Checker for Solidity.
+* [Solidifier](https://github.com/blockhousetech/research/tree/master/Solidifier): Bounded Model Checker for Solidity. ⚠️ _No commits since 2020-12._
     - Paper: [Solidifier: bounded model checking solidity using lazy contract deployment and precise memory modelling](https://dl.acm.org/doi/10.1145/3412841.3442051), Pedro Antonino & A. W. Roscoe (2021).
 * [Solidity's SMTChecker](https://github.com/argotorg/solidity): SMT and Horn-based model checker built-in the Solidity compiler which statically checks safety properties at compile-time, considering an unbounded number of transactions.
     - Slides: [Formally Verifying Ethereum Smart Contracts by Overwhelming Horn Solvers](https://raw.githubusercontent.com/leonardoalt/text/master/dagstuhl_talk/talk.pdf), Dagstuhl Seminar on Rigorous Methods for Smart Contracts, Leonardo Alt.
@@ -125,15 +125,15 @@ There is also an overwhelming amount of papers describing techniques related to 
     - Article: [SMTChecker Toward Completeness](https://medium.com/@leonardoalt/smtchecker-toward-completeness-1a99c02e0133), Leonardo Alt.
     - Paper: [Accurate Smart Contract Verification through Direct Modelling](https://github.com/leonardoalt/text/blob/master/smtchecker_chc/smtchecker_chc.pdf), Matteo Marescotti, Rodrigo Otoni, Leonardo Alt, Patrick Eugster, Antti E. J. Hyvärinen, and Natasha Sharygina (2020).
     - Paper: [SMT-Based Verification of Solidity Smart Contracts](https://github.com/leonardoalt/text/blob/master/solidity_isola_2018/main.pdf), Leonardo Alt and Christian Reitwiessner (2018).
-* [solc-verify](https://github.com/SRI-CSL/solidity): Functional verification of Solidity code using annotations and modular program verification.
+* [solc-verify](https://github.com/SRI-CSL/solidity): Functional verification of Solidity code using annotations and modular program verification. ⚠️ _No commits since 2023-09._
     - Paper: [solc-verify: A Modular Verifier for Solidity Smart Contracts](https://arxiv.org/abs/1907.04262), Á. Hajdu, D. Jovanović (2019).
     - Talk: [solc-verify, a source-level formal verification tool for Solidity smart contracts](https://www.youtube.com/watch?v=1q2gSm3NuQA), given by Á. Hajdu at Solidity Summit (2020)
     - Paper: [SMT-Friendly Formalization of the Solidity Memory Model](https://arxiv.org/abs/2001.03256), Á. Hajdu, D. Jovanović (2020).
     - Talk: [SMT-Friendly Formalization of the Solidity Memory Model](https://youtu.be/B3ML9vGituk?t=626), given by Á. Hajdu at SMT (2020)
     - Paper: [Formal Specification and Verification of Solidity Contracts with Events](https://arxiv.org/abs/2005.10382), Á. Hajdu, D. Jovanović, G. Ciocarlie (2020).
     - Talk: [Formal Specification and Verification of Solidity Contracts with Events](https://youtu.be/NNytwVBZ1no), given by Á. Hajdu at FMBC (2020).
-* [VeriSmart](https://github.com/kupl/VeriSmart-public): Safety verifier for Solidity smart contracts, based on automatic inference of contract invariants.
-* [VeriSol](https://github.com/microsoft/verisol): Formal specification, verification and scalable refutation of Solidity smart contracts using code contracts, Boogie and Corral.
+* [VeriSmart](https://github.com/kupl/VeriSmart-public): Safety verifier for Solidity smart contracts, based on automatic inference of contract invariants. ⚠️ _No commits since 2023-01._
+* [VeriSol](https://github.com/microsoft/verisol): Formal specification, verification and scalable refutation of Solidity smart contracts using code contracts, Boogie and Corral. ⚠️ _No commits since 2022-12._
     - Slides: [Formal Verification of Smart Contracts and Protocols: What, Why, How - Devcon V](https://github.com/microsoft/verisol/blob/master/Docs/devcon5-verisol.pptx), Shuvendu Lahiri et al.
     - Article: [Researchers work to secure Azure Blockchain smart contracts with formal verification](https://www.microsoft.com/en-us/research/blog/researchers-work-to-secure-azure-blockchain-smart-contracts-with-formal-verification/), Microsoft Research Blog.
     - Paper: [Formal Specification and Verification of Smart Contracts for Azure Blockchain](https://arxiv.org/abs/1812.08829), Yuepeng Wang, Shuvendu K. Lahiri, Shuo Chen, Rong Pan, Isil Dillig, Cody Born, Immad Naseer.
@@ -143,20 +143,20 @@ There is also an overwhelming amount of papers describing techniques related to 
 ### Vyper
 
 * [Vyper-HOL](https://github.com/verifereum/vyper-hol): Semantics of Vyper and verified compilation of Vyper in HOL4.
-* [2vyper](https://github.com/viperproject/2vyper): Automatic verifier for Vyper smart contracts, based on the [Viper](https://viper.ethz.ch/) verification infrastructure.
-* [FVyper](https://github.com/LayerXcom/verified-vyper-contracts): A collection of useful Vyper contracts developed with formal methods (KEVM). ⚠️ _Archived / no longer maintained._
-* [KVyper](https://github.com/kframework/vyper-semantics): Semantics of Vyper in K. ⚠️ _Unmaintained (last updated 2018)._
+* [2vyper](https://github.com/viperproject/2vyper): Automatic verifier for Vyper smart contracts, based on the [Viper](https://viper.ethz.ch/) verification infrastructure. ⚠️ _No commits since 2023-02._
+* [FVyper](https://github.com/LayerXcom/verified-vyper-contracts): A collection of useful Vyper contracts developed with formal methods (KEVM). ⚠️ _Archived; no commits since 2021-04._
+* [KVyper](https://github.com/kframework/vyper-semantics): Semantics of Vyper in K. ⚠️ _No commits since 2018-08._
 
 ## Compilers & Intermediate Languages
 
 ### Solidity / Yul
 
 * [Yul-ACL2](https://github.com/acl2/acl2/tree/master/books/kestrel/yul/language). The semantics of the IR Yul formalized in the ACL2 framework.
-* [Yul-Isabelle](https://github.com/argotorg/yul-isabelle). The semantics of the IR Yul formalized in Isabelle.
+* [Yul-Isabelle](https://github.com/argotorg/yul-isabelle). The semantics of the IR Yul formalized in Isabelle. ⚠️ _No commits since 2022-11._
 * [Yul-Lean](https://github.com/NethermindEth/Yul-Specification): A formal specification of the Yul IR semantics in the Lean proof assistant.
     - Article: [Securing Warp: A formal specification of the Yul IR](https://medium.com/nethermind-eth/securing-warp-a-formal-specification-of-the-yul-ir-85bb3bf51c62), Julian Sutherland.
 * [Solidity Optimizer Transformations](https://github.com/acl2/acl2/tree/master/books/kestrel/yul/transformations). Formalizes in ACL2 and verifies correctness of some of the Yul optimizer transformations present in the Solidity compiler.
-* [Yul-K](https://github.com/ethereum/Yul-K): The semantics of the IR Yul formalized in the K framework. ⚠️ _Archived / no longer maintained._
+* [Yul-K](https://github.com/ethereum/Yul-K): The semantics of the IR Yul formalized in the K framework. ⚠️ _Archived; no commits since 2019-10._
 
 ## Ethereum Protocol
 
@@ -168,9 +168,9 @@ There is also an overwhelming amount of papers describing techniques related to 
 * Deposit Contract (Runtime Verification): end-to-end formal verification of the Eth2 deposit contract.
     - [Part 1](https://runtimeverification.com/blog/formal-verification-of-ethereum-2-0-deposit-contract-part-1/)
     - [Part 2](https://runtimeverification.com/blog/end-to-end-formal-verification-of-ethereum-2-0-deposit-smart-contract/)
-* [Formal Verification of the Eth2.0 Specs in Dafny](https://github.com/ConsenSys/eth2.0-dafny): A formal specification of the Eth2.0 specification in the verification-aware programming language [Dafny](https://github.com/dafny-lang/dafny/wiki). ⚠️ _Archived / no longer maintained._
+* [Formal Verification of the Eth2.0 Specs in Dafny](https://github.com/ConsenSys/eth2.0-dafny): A formal specification of the Eth2.0 specification in the verification-aware programming language [Dafny](https://github.com/dafny-lang/dafny/wiki). ⚠️ _Archived; no commits since 2024-06._
 	- Paper: [Formal Verification of the Ethereum 2.0 Beacon Chain](https://arxiv.org/abs/2110.12909), Franck Cassez, Joanne Fuller, Aditya Asgaonkar.
-* [Fully Mechanised Proof of the Deposit Contract's Incremental Merkle tree algorithm in Dafny](https://github.com/ConsenSys/deposit-sc-dafny). ⚠️ _Archived / no longer maintained._
+* [Fully Mechanised Proof of the Deposit Contract's Incremental Merkle tree algorithm in Dafny](https://github.com/ConsenSys/deposit-sc-dafny). ⚠️ _Archived; no commits since 2021-09._
 
 ## Zero-Knowledge Applications & Arithmetic Circuits
 
@@ -179,16 +179,16 @@ There is also an overwhelming amount of papers describing techniques related to 
 	- [ACL2 Semaphore Docs](https://acl2.org/doc/?topic=ZKSEMAPHORE____SEMAPHORE)
 * [Cairo verification using Lean](https://github.com/starkware-libs/formal-proofs)
 	- Paper: [A verified algebraic representation of Cairo program execution](https://github.com/starkware-libs/formal-proofs), Jeremy Avigad et al.
-* [circomspect](https://github.com/trailofbits/circomspect): Trail of Bits static analyzer/linter for Circom circuits, with multiple passes that flag under-constrained signals and other circuit bugs.
+* [circomspect](https://github.com/trailofbits/circomspect): Trail of Bits static analyzer/linter for Circom circuits, with multiple passes that flag under-constrained signals and other circuit bugs. ⚠️ _No commits since 2024-06._
 * [circuzz](https://github.com/Rigorous-Software-Engineering/circuzz): Metamorphic and differential fuzzing pipeline for zero-knowledge circuit compiler toolchains.
 * [CIVER](https://github.com/costa-group/circom_civer): Modular verifier of weak safety (absence of under-constrained signals), tag specifications, and pre/postconditions for Circom circuits.
 * [Coda](https://eprint.iacr.org/2023/547): A statically-typed language for ZK circuits with a refinement type system that discharges proof obligations to Coq.
-* [Ecne](https://github.com/franklynwang/EcneProject): An engine for verifying the soundness of R1CS constraints.
-* [gnark-lean-extractor](https://github.com/reilabs/gnark-lean-extractor): Extracts gnark (zk-SNARK library) circuits defined in Go into Lean for formal verification.
+* [Ecne](https://github.com/franklynwang/EcneProject): An engine for verifying the soundness of R1CS constraints. ⚠️ _No commits since 2022-08._
+* [gnark-lean-extractor](https://github.com/reilabs/gnark-lean-extractor): Extracts gnark (zk-SNARK library) circuits defined in Go into Lean for formal verification. ⚠️ _No commits since 2025-04._
 * [Korrekt (halo2-analyzer)](https://github.com/quantstamp/halo2-analyzer): Uses abstract interpretation and SMT to detect under-constrained cells and unused gates/columns in Halo2 (PLONKish) circuits.
 * [Leo](https://github.com/ProvableHQ/leo)
 	- Paper: [LEO: A Programming Language for Formally Verified, Zero-Knowledge Applications](https://eprint.iacr.org/2021/651.pdf)
-* [Picus](https://github.com/Veridise/Picus): Automated verifier (Veridise) for the uniqueness / under-constrained property of ZKP circuits (Circom, R1CS, gnark), using SMT solvers.
+* [Picus](https://github.com/Veridise/Picus): Automated verifier (Veridise) for the uniqueness / under-constrained property of ZKP circuits (Circom, R1CS, gnark), using SMT solvers. ⚠️ _No commits since 2024-03 (an actively maintained fork lives at [chyanju/Picus](https://github.com/chyanju/Picus))._
 * [Verified zk(E)VM](https://github.com/Verified-zkEVM): A research effort accelerating the application of formal verification to zk(E)VMs in Lean ([verified-zkevm.org](https://verified-zkevm.org)).
 	- [ArkLib](https://github.com/Verified-zkEVM/ArkLib): Formally verified arguments of knowledge in Lean.
 	- [clean](https://github.com/Verified-zkEVM/clean): A verified Lean circuit DSL.


### PR DESCRIPTION
Follow-up to #25. Two commits:

### 1. Add more formal-verification projects
Adds the projects you flagged plus further ones found by searching the ecosystem. Every link verified live; inserted alphabetically within each section.

- **Requested:** EVMYulLean, evm-smith, Verity, and the Verified zk(E)VM org (with ArkLib + clean sub-entries).
- **EVM Bytecode:** Halmos (a16z), Kontrol (Runtime Verification).
- **Solidity:** Clear (Nethermind), Pyrometer (Nascent), Wake (Ackee).
- **Fuzzing:** ItyFuzz.
- **ZK & Arithmetic Circuits:** Picus, circomspect, CIVER, zkFuzz, circuzz, gnark-lean-extractor, Korrekt/halo2-analyzer, Coda.

### 2. Mark repos with no commits in over a year
Mechanical staleness rule: every primary GitHub entry whose last push predates **2025-06-08** gets a `⚠️` note with its last-commit month (dates from the GitHub API). The legend now states the one-year criterion, and the wording acknowledges an inactive project may still be perfectly usable.

- **Newly marked (19):** Formal Methods for DeFi Developers, Clockwork Finance, EthBMC, EthIsabelle, MAIAN, Securify, Pyrometer, SmartAce, SmartCheck, Solidifier, solc-verify, VeriSmart, VeriSol, 2vyper, Yul-Isabelle, circomspect, Ecne, gnark-lean-extractor, Picus.
- **Existing markers** (KLab, Oyente, FVyper, KVyper, Yul-K, eth2.0-dafny, deposit-sc-dafny) reworded to the same dated format.

Notes:
- Marked entries are kept **in place** rather than moved to section-ends — with staleness now the common case for research tooling, bottom-stacking ~half the list would hurt readability. Easy to switch back to the move-to-end convention if you prefer.
- Non-GitHub project homepages (Certora, VerX, eThor, EtherTrust, Verifereum, etc.) are left untouched — no measurable commit date.
- **Skipped as out of scope:** ConCert (Coq, non-Ethereum chains), Aderyn (pattern linter), commercial-only services.

Opened as a **draft** — happy to trim, recategorize, or change the staleness presentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)